### PR TITLE
Fix Android AudioEncoder

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
@@ -26,12 +26,12 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 28
     buildToolsVersion '25.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/android/src/main/java/com/jordanalcaraz/audiorecorder/audiorecorder/AudioRecorderPlugin.java
+++ b/android/src/main/java/com/jordanalcaraz/audiorecorder/audiorecorder/AudioRecorderPlugin.java
@@ -96,7 +96,7 @@ public class AudioRecorderPlugin implements MethodCallHandler {
     mRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
     mRecorder.setOutputFormat(getOutputFormatFromString(mExtension));
     mRecorder.setOutputFile(mFilePath);
-    mRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
+    mRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
 
     try {
       mRecorder.prepare();

--- a/ios/Classes/SwiftAudioRecorderPlugin.swift
+++ b/ios/Classes/SwiftAudioRecorderPlugin.swift
@@ -36,7 +36,11 @@ public class SwiftAudioRecorderPlugin: NSObject, FlutterPlugin, AVAudioRecorderD
                 AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
             ]
             do {
-                try AVAudioSession.sharedInstance().setCategory(.playAndRecord, mode: .default, options: .defaultToSpeaker)
+                if #available(iOS 10.0, *) {
+                    try AVAudioSession.sharedInstance().setCategory(.playAndRecord, mode: .default, options: .defaultToSpeaker)
+                } else {
+                    // Fallback on earlier versions
+                }
                 try AVAudioSession.sharedInstance().setActive(true)
 
                 audioRecorder = try AVAudioRecorder(url: URL(string: mPath)!, settings: settings)

--- a/ios/Classes/SwiftAudioRecorderPlugin.swift
+++ b/ios/Classes/SwiftAudioRecorderPlugin.swift
@@ -1,7 +1,7 @@
 import Flutter
 import UIKit
 import AVFoundation
-    
+
 public class SwiftAudioRecorderPlugin: NSObject, FlutterPlugin, AVAudioRecorderDelegate {
     var isRecording = false
     var hasPermissions = false
@@ -36,9 +36,9 @@ public class SwiftAudioRecorderPlugin: NSObject, FlutterPlugin, AVAudioRecorderD
                 AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
             ]
             do {
-                try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayAndRecord, with: AVAudioSessionCategoryOptions.defaultToSpeaker)
+                try AVAudioSession.sharedInstance().setCategory(.playAndRecord, mode: .default, options: .defaultToSpeaker)
                 try AVAudioSession.sharedInstance().setActive(true)
-                
+
                 audioRecorder = try AVAudioRecorder(url: URL(string: mPath)!, settings: settings)
                 audioRecorder.delegate = self
                 audioRecorder.record()
@@ -64,17 +64,17 @@ public class SwiftAudioRecorderPlugin: NSObject, FlutterPlugin, AVAudioRecorderD
             result(isRecording)
         case "hasPermissions":
             print("hasPermissions")
-            switch AVAudioSession.sharedInstance().recordPermission() {
-            case AVAudioSessionRecordPermission.granted:
-                NSLog("granted")
+            switch AVAudioSession.sharedInstance().recordPermission{
+            case AVAudioSession.RecordPermission.granted:
+                print("granted")
                 hasPermissions = true
                 break
-            case AVAudioSessionRecordPermission.denied:
-                NSLog("denied")
+            case AVAudioSession.RecordPermission.denied:
+                print("denied")
                 hasPermissions = false
                 break
-            case AVAudioSessionRecordPermission.undetermined:
-                NSLog("undetermined")
+            case AVAudioSession.RecordPermission.undetermined:
+                print("undetermined")
                 AVAudioSession.sharedInstance().requestRecordPermission() { [unowned self] allowed in
                     DispatchQueue.main.async {
                         if allowed {
@@ -103,4 +103,3 @@ public class SwiftAudioRecorderPlugin: NSObject, FlutterPlugin, AVAudioRecorderD
             }
         }
     }
-

--- a/ios/audio_recorder.podspec
+++ b/ios/audio_recorder.podspec
@@ -15,5 +15,5 @@ A new Flutter plugin.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '9.3'
 end

--- a/ios/audio_recorder.podspec
+++ b/ios/audio_recorder.podspec
@@ -15,6 +15,5 @@ A new Flutter plugin.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.static_framework = true
   s.ios.deployment_target = '10.0'
 end

--- a/ios/audio_recorder.podspec
+++ b/ios/audio_recorder.podspec
@@ -15,7 +15,6 @@ A new Flutter plugin.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  
+  s.static_framework = true
   s.ios.deployment_target = '8.0'
 end
-

--- a/ios/audio_recorder.podspec
+++ b/ios/audio_recorder.podspec
@@ -16,5 +16,5 @@ A new Flutter plugin.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.static_framework = true
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '10.0'
 end

--- a/lib/audio_recorder.dart
+++ b/lib/audio_recorder.dart
@@ -46,7 +46,7 @@ class AudioRecorder {
 
   static Future<Recording> stop() async {
     Map<String, Object> response =
-        Map.from<String, Object>(await _channel.invokeMethod('stop'));
+        Map.from(await _channel.invokeMethod('stop'));
     Recording recording = new Recording(
         duration: new Duration(milliseconds: response['duration']),
         path: response['path'],


### PR DESCRIPTION
As reported on this [issue](https://github.com/ZaraclaJ/audio_recorder/issues/20) audios recorded from Android cannot be played on iOS, the reason is the record `MediaRecorder.AudioEncoder` format `AMR_NB` create a confusion for some players and the mime-type becomes `video/mp4`.

Thats the file I recorded using Android
```02ad9210-bd30-11e8-80ae-094b53e3c499.m4a:                    video/mp4```

Android docs about the problem
https://developer.android.com/reference/android/media/MediaRecorder#setOutputFormat(int)